### PR TITLE
process response now separate by run_scan for each set of results

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -609,9 +609,10 @@ async def export_project(projectName: str):
         return {"status": "failure", "error": f"Export failed: {str(e)}"}
     
 @app.post("/submit_results/{result_type}")
-async def submit_results(request: Request, result_type):
+async def submit_results(result_type, file: UploadFile=File(...)):
     try:
-        test_data = await request.json()
+        test_data = await file.read()
+        test_data=json.loads(test_data)
         pm.submit_results(test_data, result_type)
     except Exception as e:
         return {"status": "failure", "error": f"Export failed: {str(e)}"}

--- a/frontend/src/routes/main/deleted-projects/+page.svelte
+++ b/frontend/src/routes/main/deleted-projects/+page.svelte
@@ -60,7 +60,7 @@
   // Function to send the specific test data
   async function sendTestData() {
     const jsonData = {
-      "id": 2000,
+      "id": 10101,
       "url": "https://discord.com",
       "title": "Discord - Group Chat That\u00e2\u0080\u0099s All Fun & Games",
       "word_count": 376,
@@ -70,7 +70,7 @@
     };
 
     try {
-      const response = await fetch(`http://localhost:8000/submit_results/crawler`, {
+      const response = await fetch(`http://localhost:8000/submit_results/Fuzzer`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
I have added the the results for the DB but i still need to view with my team about the enpoint for handling files but now you can add the whole 24 results of a crawler and it will be associated to a scan_result for that specific run with unique identifier and type of results that scan_result contain.